### PR TITLE
Code style and functionality

### DIFF
--- a/PSWriteColor.psd1
+++ b/PSWriteColor.psd1
@@ -46,10 +46,10 @@
     # PowerShellHostVersion = ''
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-    FunctionsToExport = 'Write-Color'
+    FunctionsToExport = @('Write-Color')
 
     # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-    AliasesToExport   = 'wc'
+    AliasesToExport   = @('wc')
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
     PrivateData       = @{

--- a/PSWriteColor.psm1
+++ b/PSWriteColor.psm1
@@ -90,7 +90,6 @@ function Write-Color {
         - TimeFormat https://msdn.microsoft.com/en-us/library/8kb3ddd4.aspx
     #>
     [CmdletBinding()]
-    [Alias('wc')]
     param(
         [Parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias('Text')]
@@ -106,17 +105,17 @@ function Write-Color {
         $BackgroundColor,
 
         [Alias('StartTab')]
-        [ValidateRange(0, [int32]::MaxValue)]
+        [ValidateRange(0, 5)]
         [int]
-        $StartTab = 0,
+        $Indent = 0,
 
         [Alias('LinesBefore')]
-        [ValidateRange(0, [int32]::MaxValue)]
+        [ValidateRange(0, 10)]
         [int]
         $LeadingSpace = 0,
 
         [Alias('LinesAfter')]
-        [ValidateRange(0, [int32]::MaxValue)]
+        [ValidateRange(0, 10)]
         [int]
         $TrailingSpace = 0,
 
@@ -173,7 +172,7 @@ function Write-Color {
     }
     process {
         # Add TABS before text
-        Write-Host ("`t" * $StartTab) @BaseParams
+        Write-Host ("`t" * $Indent) @BaseParams
 
         if ($PSBoundParameters.ContainsKey('ForegroundColor') -or $PSBoundParameters.ContainsKey('BackgroundColor')) {
             # Fallback defaults if one of the values isn't set

--- a/PSWriteColor.psm1
+++ b/PSWriteColor.psm1
@@ -1,228 +1,141 @@
 function Write-Color {
     <#
 	.SYNOPSIS
-        Write-Color is a wrapper around Write-Host.
-
-        It provides:
-        - Easy manipulation of colors,
-        - Logging output to file (log)
-        - Nice formatting options out of the box.
-
+	Write-Color is a wrapper around Write-Host.
+	It provides:
+	- easy manipulation of colors,
+	- logging output to file (log)
+	- nice formatting options out of the box.
 	.DESCRIPTION
-        Author: przemyslaw.klys at evotec.pl
-        Project website: https://evotec.xyz/hub/scripts/write-color-ps1/
-        Project support: https://github.com/EvotecIT/PSWriteColor
+	Author: przemyslaw.klys at evotec.pl
+	Project website: https://evotec.xyz/hub/scripts/write-color-ps1/
+	Project support: https://github.com/EvotecIT/PSWriteColor
 
-        Original idea: Josh (https://stackoverflow.com/users/81769/josh)
+	Original idea: Josh (https://stackoverflow.com/users/81769/josh)
+
+    version 0.5 (25th April 2018
+    - added backgroundcolor
+    - added aliases T/B/C to shorter code
+    - added alias to function (can be used with "WC")
+	- fixes to module publishing
+
+	version 0.4.0-0.4.9 (25th April 2018)
+	- published as module
+	- fixed small issues
+
+	version 0.31 (20th April 2018)
+	- Added Try/Catch for Write-Output (might need some additional work)
+	- Small change to parameters
+
+	version 0.3 (9th April 2018)
+	- added -ShowTime
+	- added -NoNewLine
+	- added function description
+	- changed some formatting
+
+	version 0.2
+	- added logging to file
+
+	version 0.1
+	- first draft
+
+	Notes:
+	- TimeFormat https://msdn.microsoft.com/en-us/library/8kb3ddd4.aspx
 
 	.EXAMPLE
-    Write-Color -Text "Red ", "Green ", "Yellow " -Color Red,Green,Yellow
+	Write-Color -Text "Red ", "Green ", "Yellow " -Color Red,Green,Yellow
 
-    .EXAMPLE
 	Write-Color -Text "This is text in Green ",
 					"followed by red ",
 					"and then we have Magenta... ",
 					"isn't it fun? ",
 					"Here goes DarkCyan" -Color Green,Red,Magenta,White,DarkCyan
 
-    .EXAMPLE
 	Write-Color -Text "This is text in Green ",
 					"followed by red ",
 					"and then we have Magenta... ",
 					"isn't it fun? ",
-                    "Here goes DarkCyan" -Color Green,Red,Magenta,White,DarkCyan -StartTab 3 -LinesBefore 1 -LinesAfter 1
+					"Here goes DarkCyan" -Color Green,Red,Magenta,White,DarkCyan -StartTab 3 -LinesBefore 1 -LinesAfter 1
 
-    .EXAMPLE
 	Write-Color "1. ", "Option 1" -Color Yellow, Green
 	Write-Color "2. ", "Option 2" -Color Yellow, Green
 	Write-Color "3. ", "Option 3" -Color Yellow, Green
 	Write-Color "4. ", "Option 4" -Color Yellow, Green
 	Write-Color "9. ", "Press 9 to exit" -Color Yellow, Gray -LinesBefore 1
 
-    .EXAMPLE
 	Write-Color -LinesBefore 2 -Text "This little ","message is ", "written to log ", "file as well." `
 				-Color Yellow, White, Green, Red, Red -LogFile "C:\testing.txt" -TimeFormat "yyyy-MM-dd HH:mm:ss"
 	Write-Color -Text "This can get ","handy if ", "want to display things, and log actions to file ", "at the same time." `
 				-Color Yellow, White, Green, Red, Red -LogFile "C:\testing.txt"
 
-    .EXAMPLE
+
     # Added in 0.5
     Write-Color -T "My text", " is ", "all colorful" -C Yellow, Red, Green -B Green, Green, Yellow
     wc -t "my text" -c yellow -b green
     wc -text "my text" -c red
 
-    .NOTES
-        CHANGELOG
-
-        Version 0.5 (25th April 2018)
-        -----------
-        - Added backgroundcolor
-        - Added aliases T/B/C to shorter code
-        - Added alias to function (can be used with "WC")
-        - Fixes to module publishing
-
-        Version 0.4.0-0.4.9 (25th April 2018)
-        -------------------
-        - Published as module
-        - Fixed small issues
-
-        Version 0.31 (20th April 2018)
-        ------------
-        - Added Try/Catch for Write-Output (might need some additional work)
-        - Small change to parameters
-
-        Version 0.3 (9th April 2018)
-        -----------
-        - Added -ShowTime
-        - Added -NoNewLine
-        - Added function description
-        - Changed some formatting
-
-        Version 0.2
-        -----------
-        - Added logging to file
-
-        Version 0.1
-        -----------
-        - First draft
-
-        Additional Notes:
-        - TimeFormat https://msdn.microsoft.com/en-us/library/8kb3ddd4.aspx
     #>
     [CmdletBinding()]
-    param(
-        [Parameter(Position = 0, Mandatory, ValueFromPipeline)]
-        [Alias('Text')]
-        [string[]]
-        $Message,
-
-        [Alias('Color', 'FGC')]
-        [ConsoleColor[]]
-        $ForegroundColor = 'White',
-
-        [Alias('BGC')]
-        [ConsoleColor[]]
-        $BackgroundColor,
-
-        [Alias('StartTab')]
-        [ValidateRange(0, 5)]
-        [int]
-        $Indent = 0,
-
-        [Alias('LinesBefore')]
-        [ValidateRange(0, 10)]
-        [int]
-        $LeadingSpace = 0,
-
-        [Alias('LinesAfter')]
-        [ValidateRange(0, 10)]
-        [int]
-        $TrailingSpace = 0,
-
-        [Alias('File', 'L')]
-        [ValidateScript( { Test-Path -IsValid $_ })]
-        [string]
-        $LogFile,
-
-        [Alias('DateFormat', 'TimeFormat')]
-        [string]
-        $DateTimeFormat = "yyyy-MM-dd HH:mm:ss",
-
-        [Alias('LTS')]
-        [switch]
-        $NoLogTimestamp,
-
-        [Alias('Encoding')]
-        [System.Text.Encoding]
-        $OutputEncoding = [System.Text.Encoding]::UTF8,
-
-        [switch]
-        $ShowTime,
-
-        [switch]
-        $NoNewLine
+    [Alias("wc")]
+    param (
+        [alias ("T")] [String[]]$Text,
+        [alias ("C")] [ConsoleColor[]]$Color = "White",
+        [alias ("B")] [ConsoleColor[]]$BackGroundColor = $null,
+        [int] $StartTab = 0,
+        [int] $LinesBefore = 0,
+        [int] $LinesAfter = 0,
+        [alias ("L")] [string] $LogFile = "",
+        [string] $TimeFormat = "yyyy-MM-dd HH:mm:ss",
+        [alias ('LogTimeStamp')][bool] $LogTime = $true,
+        [ValidateSet("unknown", "string", "unicode", "bigendianunicode", "utf8", "utf7", "utf32", "ascii", "default", "oem")][string]$Encoding = 'Unicode',
+        [switch] $ShowTime,
+        [switch] $NoNewLine
     )
-    begin {
-        if ($PSBoundParameters.ContainsKey('LogFile')) { $StringBuilder = [System.Text.StringBuilder]::new() }
-
-        $InvalidParams = ($BackgroundColor.Count -gt 0 -and $BackgroundColor.Count -ne $ForegroundColor.Count) -or
-        $ForegroundColor.Count -gt $Message.Count -or
-        $BackgroundColor.Count -gt $Message.Count
-
-        if ($InvalidParams) {
-            $ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
-                [System.Management.Automation.ParameterBindingException]::new(
-                    'The number of provided Foreground and Background colors does not match, or more colors were provided than entered messages.'
-                ),
-                'InvalidColorMapping', # ErrorID
-                [System.Management.Automation.ErrorCategory]::InvalidArgument, # Category
-                $null # Target
-            )
-
-            $PSCmdlet.ThrowTerminatingError($ErrorRecord)
-        }
-
-        # Add leading lines
-        Write-Host ("`n" * $LeadingSpace) @BaseParams
-
-        if ($ShowTime) {
-            # Add Time before output
-            Write-Host ('[{0}]' -f [datetime]::Now.ToString($DateTimeFormat)) @BaseParams
-        }
-    }
-    process {
-        # Add TABS before text
-        Write-Host ("`t" * $Indent) @BaseParams
-
-        if ($PSBoundParameters.ContainsKey('ForegroundColor') -or $PSBoundParameters.ContainsKey('BackgroundColor')) {
-            # Fallback defaults if one of the values isn't set
-            $LastForegroundColor = [console]::ForegroundColor
-            $LastForegroundColor = [console]::BackgroundColor
-
-            # The real deal coloring
-            for ($i = 0; $i -lt $Message.Count; $i++) {
-                $CurrentFGColor = if ($ForegroundColor[$i]) { $ForegroundColor[$i] } else { $LastForegroundColor }
-                $CurrentBGColor = if ($BackgroundColor[$i]) { $BackgroundColor[$i] } else { $LastBackgroundColor }
-
-                $WriteParams = @{
-                    NoNewLine       = $true
-                    ForegroundColor = $CurrentFGColor
-                    BackgroundColor = $CurrentBGColor
-                }
-
-                Write-Host $Message[$i] @WriteParams
-                if ($PSBoundParameters.ContainsKey('LogFile')) { $StringBuilder.Append($Message[$i]) > $null }
-
-                # Store last color set, in case next iteration doesn't have a set color
-                $LastForegroundColor, $LastBackgroundColor = $CurrentFGColor, $CurrentBGColor
-            }
+    $DefaultColor = $Color[0]
+    if ($BackGroundColor -ne $null -and $BackGroundColor.Count -ne $Color.Count) { Write-Error "Colors, BackGroundColors parameters count doesn't match. Terminated." ; return }
+    if ($Text.Count -eq 0) { return }
+    if ($LinesBefore -ne 0) {  for ($i = 0; $i -lt $LinesBefore; $i++) { Write-Host -Object "`n" -NoNewline } } # Add empty line before
+    if ($ShowTime) { Write-Host -Object "[$([datetime]::Now.ToString($TimeFormat))]" -NoNewline} # Add Time before output
+    if ($StartTab -ne 0) {  for ($i = 0; $i -lt $StartTab; $i++) { Write-Host -Object "`t" -NoNewLine } }  # Add TABS before text
+    if ($Color.Count -ge $Text.Count) {
+        # the real deal coloring
+        if ($BackGroundColor -eq $null) {
+            for ($i = 0; $i -lt $Text.Length; $i++) { Write-Host -Object $Text[$i] -ForegroundColor $Color[$i] -NoNewLine }
         }
         else {
-            Write-Host $Message -NoNewline
+            for ($i = 0; $i -lt $Text.Length; $i++) { Write-Host -Object $Text[$i] -ForegroundColor $Color[$i] -BackgroundColor $BackGroundColor[$i] -NoNewLine }
         }
-
-        if (-not $NoNewLine) {
-            Write-Host
-        }
-
-        Write-Host ("`n" * $TrailingSpace) # Add empty line after
     }
-    end {
-        if ($PSBoundParameters.ContainsKey('LogFile')) {
-            # Save to file
-
-            try {
-                if ($NoLogTimestamp) {
-                    $StringBuilder.ToString() | Add-Content -Path $LogFile -Encoding $OutputEncoding
-                }
-                else {
-                    "[{0}]{1}" -f [datetime]::Now.ToString($DateTimeFormat), $StringBuilder.ToString() |
-                        Add-Content -Path $LogFile -Encoding $OutputEncoding
-                }
+    else {
+        if ($BackGroundColor -eq $null) {
+            for ($i = 0; $i -lt $Color.Length ; $i++) { Write-Host -Object $Text[$i] -ForegroundColor $Color[$i] -NoNewLine }
+            for ($i = $Color.Length; $i -lt $Text.Length; $i++) { Write-Host -Object $Text[$i] -ForegroundColor $DefaultColor -NoNewLine }
+        }
+        else {
+            for ($i = 0; $i -lt $Color.Length ; $i++) { Write-Host -Object $Text[$i] -ForegroundColor $Color[$i] -BackgroundColor $BackGroundColor[$i] -NoNewLine }
+            for ($i = $Color.Length; $i -lt $Text.Length; $i++) { Write-Host -Object $Text[$i] -ForegroundColor $DefaultColor -BackgroundColor $BackGroundColor[0] -NoNewLine }
+        }
+    }
+    if ($NoNewLine -eq $true) { Write-Host -NoNewline } else { Write-Host } # Support for no new line
+    if ($LinesAfter -ne 0) {  for ($i = 0; $i -lt $LinesAfter; $i++) { Write-Host -Object "`n" } }  # Add empty line after
+    if ($LogFile -ne "") {
+        # Save to file
+        $TextToFile = ""
+        for ($i = 0; $i -lt $Text.Length; $i++) {
+            $TextToFile += $Text[$i]
+        }
+        try {
+            if ($LogTime) {
+                Write-Output -InputObject "[$([datetime]::Now.ToString($TimeFormat))]$TextToFile" | Out-File -FilePath $LogFile -Encoding $Encoding -Append
             }
-            catch {
-                $PSCmdlet.WriteError($_)
+            else {
+                Write-Output -InputObject "$TextToFile" | Out-File -FilePath $LogFile -Encoding $Encoding -Append
             }
+        }
+        catch {
+            $_.Exception
         }
     }
 }
+
+Export-ModuleMember -function 'Write-Color' -Alias 'wc'

--- a/PSWriteColor.psm1
+++ b/PSWriteColor.psm1
@@ -1,133 +1,222 @@
 function Write-Color {
     <#
 	.SYNOPSIS
-	Write-Color is a wrapper around Write-Host.
-	It provides:
-	- easy manipulation of colors,
-	- logging output to file (log)
-	- nice formatting options out of the box.
+        Write-Color is a wrapper around Write-Host.
+
+        It provides:
+        - Easy manipulation of colors,
+        - Logging output to file (log)
+        - Nice formatting options out of the box.
+
 	.DESCRIPTION
-	Author: przemyslaw.klys at evotec.pl
-	Project website: https://evotec.xyz/hub/scripts/write-color-ps1/
-	Project support: https://github.com/EvotecIT/PSWriteColor
+        Author: przemyslaw.klys at evotec.pl
+        Project website: https://evotec.xyz/hub/scripts/write-color-ps1/
+        Project support: https://github.com/EvotecIT/PSWriteColor
 
-	Original idea: Josh (https://stackoverflow.com/users/81769/josh)
-
-    version 0.5 (25th April 2018
-    - added backgroundcolor
-    - added aliases T/B/C to shorter code
-    - added alias to function (can be used with "WC")
-	- fixes to module publishing
-
-	version 0.4.0-0.4.9 (25th April 2018)
-	- published as module
-	- fixed small issues
-
-	version 0.31 (20th April 2018)
-	- Added Try/Catch for Write-Output (might need some additional work)
-	- Small change to parameters
-
-	version 0.3 (9th April 2018)
-	- added -ShowTime
-	- added -NoNewLine
-	- added function description
-	- changed some formatting
-
-	version 0.2
-	- added logging to file
-
-	version 0.1
-	- first draft
-
-	Notes:
-	- TimeFormat https://msdn.microsoft.com/en-us/library/8kb3ddd4.aspx
+        Original idea: Josh (https://stackoverflow.com/users/81769/josh)
 
 	.EXAMPLE
-	Write-Color -Text "Red ", "Green ", "Yellow " -Color Red,Green,Yellow
+    Write-Color -Text "Red ", "Green ", "Yellow " -Color Red,Green,Yellow
 
+    .EXAMPLE
 	Write-Color -Text "This is text in Green ",
 					"followed by red ",
 					"and then we have Magenta... ",
 					"isn't it fun? ",
 					"Here goes DarkCyan" -Color Green,Red,Magenta,White,DarkCyan
 
+    .EXAMPLE
 	Write-Color -Text "This is text in Green ",
 					"followed by red ",
 					"and then we have Magenta... ",
 					"isn't it fun? ",
-					"Here goes DarkCyan" -Color Green,Red,Magenta,White,DarkCyan -StartTab 3 -LinesBefore 1 -LinesAfter 1
+                    "Here goes DarkCyan" -Color Green,Red,Magenta,White,DarkCyan -StartTab 3 -LinesBefore 1 -LinesAfter 1
 
+    .EXAMPLE
 	Write-Color "1. ", "Option 1" -Color Yellow, Green
 	Write-Color "2. ", "Option 2" -Color Yellow, Green
 	Write-Color "3. ", "Option 3" -Color Yellow, Green
 	Write-Color "4. ", "Option 4" -Color Yellow, Green
 	Write-Color "9. ", "Press 9 to exit" -Color Yellow, Gray -LinesBefore 1
 
+    .EXAMPLE
 	Write-Color -LinesBefore 2 -Text "This little ","message is ", "written to log ", "file as well." `
 				-Color Yellow, White, Green, Red, Red -LogFile "C:\testing.txt" -TimeFormat "yyyy-MM-dd HH:mm:ss"
 	Write-Color -Text "This can get ","handy if ", "want to display things, and log actions to file ", "at the same time." `
 				-Color Yellow, White, Green, Red, Red -LogFile "C:\testing.txt"
 
-
+    .EXAMPLE
     # Added in 0.5
     Write-Color -T "My text", " is ", "all colorful" -C Yellow, Red, Green -B Green, Green, Yellow
     wc -t "my text" -c yellow -b green
     wc -text "my text" -c red
 
+    .NOTES
+        CHANGELOG
+
+        Version 0.5 (25th April 2018)
+        -----------
+        - Added backgroundcolor
+        - Added aliases T/B/C to shorter code
+        - Added alias to function (can be used with "WC")
+        - Fixes to module publishing
+
+        Version 0.4.0-0.4.9 (25th April 2018)
+        -------------------
+        - Published as module
+        - Fixed small issues
+
+        Version 0.31 (20th April 2018)
+        ------------
+        - Added Try/Catch for Write-Output (might need some additional work)
+        - Small change to parameters
+
+        Version 0.3 (9th April 2018)
+        -----------
+        - Added -ShowTime
+        - Added -NoNewLine
+        - Added function description
+        - Changed some formatting
+
+        Version 0.2
+        -----------
+        - Added logging to file
+
+        Version 0.1
+        -----------
+        - First draft
+
+        Additional Notes:
+        - TimeFormat https://msdn.microsoft.com/en-us/library/8kb3ddd4.aspx
     #>
-    [Alias("wc")]
-    param (
-        [alias ("T")] [String[]]$Text,
-        [alias ("C")] [ConsoleColor[]]$Color = "White",
-        [alias ("B")] [ConsoleColor[]]$BackGroundColor = $null,
-        [int] $StartTab = 0,
-        [int] $LinesBefore = 0,
-        [int] $LinesAfter = 0,
-        [alias ("L")] [string] $LogFile = "",
-        [string] $TimeFormat = "yyyy-MM-dd HH:mm:ss",
-        [alias ('LogTimeStamp')][bool] $LogTime = $true,
-        [ValidateSet("unknown", "string", "unicode", "bigendianunicode", "utf8", "utf7", "utf32", "ascii", "default", "oem")][string]$Encoding = 'Unicode',
-        [switch] $ShowTime,
-        [switch] $NoNewLine
+    [CmdletBinding()]
+    [Alias('wc')]
+    param(
+        [Parameter(Position = 0, Mandatory, ValueFromPipeline)]
+        [Alias('Text')]
+        [string[]]
+        $Message,
+
+        [Alias('Color', 'FGC')]
+        [ConsoleColor[]]
+        $ForegroundColor = 'White',
+
+        [Alias('BGC')]
+        [ConsoleColor[]]
+        $BackgroundColor,
+
+        [Alias('StartTab')]
+        [ValidateRange(0, [int32]::MaxValue)]
+        [int]
+        $StartTab = 0,
+
+        [Alias('LinesBefore')]
+        [ValidateRange(0, [int32]::MaxValue)]
+        [int]
+        $LeadingSpace = 0,
+
+        [Alias('LinesAfter')]
+        [ValidateRange(0, [int32]::MaxValue)]
+        [int]
+        $TrailingSpace = 0,
+
+        [Alias('File', 'L')]
+        [ValidateScript( { Test-Path -IsValid $_ })]
+        [string]
+        $LogFile,
+
+        [Alias('DateFormat', 'TimeFormat')]
+        [string]
+        $DateTimeFormat = "yyyy-MM-dd HH:mm:ss",
+
+        [Alias('LTS')]
+        [switch]
+        $NoLogTimestamp,
+
+        [Alias('Encoding')]
+        [System.Text.Encoding]
+        $OutputEncoding = [System.Text.Encoding]::UTF8,
+
+        [switch]
+        $ShowTime,
+
+        [switch]
+        $NoNewLine
     )
-    $DefaultColor = $Color[0]
-    if ($BackGroundColor -ne $null -and $BackGroundColor.Count -ne $Color.Count) { Write-Error "Colors, BackGroundColors parameters count doesn't match. Terminated." ; return }
-    if ($Text.Count -eq 0) { return }
-    if ($LinesBefore -ne 0) {  for ($i = 0; $i -lt $LinesBefore; $i++) { Write-Host -Object "`n" -NoNewline } } # Add empty line before
-    if ($ShowTime) { Write-Host -Object "[$([datetime]::Now.ToString($TimeFormat))]" -NoNewline} # Add Time before output
-    if ($StartTab -ne 0) {  for ($i = 0; $i -lt $StartTab; $i++) { Write-Host -Object "`t" -NoNewLine } }  # Add TABS before text
-    if ($Color.Count -ge $Text.Count) {
-        # the real deal coloring
-        if ($BackGroundColor -eq $null) {
-            for ($i = 0; $i -lt $Text.Length; $i++) { Write-Host -Object $Text[$i] -ForegroundColor $Color[$i] -NoNewLine }
-        } else {
-            for ($i = 0; $i -lt $Text.Length; $i++) { Write-Host -Object $Text[$i] -ForegroundColor $Color[$i] -BackgroundColor $BackGroundColor[$i] -NoNewLine }
+
+    $DefaultColor = $ForegroundColor[0]
+    if (
+        $BackgroundColor.Count -gt 0 -and $BackgroundColor.Count -ne $ForegroundColor.Count -or
+        $ForegroundColor.Count -gt $Message.Count -or
+        $BackgroundColor.Count -gt $Message.Count
+    ) {
+        $ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
+            [System.Management.Automation.ParameterBindingException]::new(
+                'The number of provided Foreground and Background colors does not match, or more colors were provided than entered messages.'
+            ),
+            'InvalidColorMapping', # ErrorID
+            [System.Management.Automation.ErrorCategory]::InvalidArgument, # Category
+            $null # Target
+        )
+
+        $PSCmdlet.ThrowTerminatingError($ErrorRecord)
+    }
+
+    # Add leading lines
+    Write-Host -Object ("`n" * $LeadingSpace) -NoNewline
+
+    if ($ShowTime) {
+        # Add Time before output
+        Write-Host -Object ('[{0}]' -f [datetime]::Now.ToString($DateTimeFormat)) -NoNewline
+    }
+
+    # Add TABS before text
+    Write-Host -Object ("`t" * $StartTab) -NoNewLine
+
+    if ($ForegroundColor.Count -ge $Message.Count) {
+        # The real deal coloring
+        for ($i = 0; $i -lt $Message.Length; $i++) {
+            $WriteParams = @{
+                ForegroundColor = $ForegroundColor[$i]
+                BackgroundColor = $BackgroundColor[$i]
+                NoNewLine       = $true
+            }
+
+            Write-Host -Object $Message[$i] @WriteParams
         }
-    } else {
-        if ($BackGroundColor -eq $null) {
-            for ($i = 0; $i -lt $Color.Length ; $i++) { Write-Host -Object $Text[$i] -ForegroundColor $Color[$i] -NoNewLine }
-            for ($i = $Color.Length; $i -lt $Text.Length; $i++) { Write-Host -Object $Text[$i] -ForegroundColor $DefaultColor -NoNewLine }
-        } else {
-            for ($i = 0; $i -lt $Color.Length ; $i++) { Write-Host -Object $Text[$i] -ForegroundColor $Color[$i] -BackgroundColor $BackGroundColor[$i] -NoNewLine }
-            for ($i = $Color.Length; $i -lt $Text.Length; $i++) { Write-Host -Object $Text[$i] -ForegroundColor $DefaultColor -BackgroundColor $BackGroundColor[0] -NoNewLine }
+
+    }
+    else {
+        if ($null -eq $BackgroundColor) {
+            for ($i = 0; $i -lt $ForegroundColor.Length ; $i++) { Write-Host -Object $Message[$i] -ForegroundColor $ForegroundColor[$i] -NoNewLine }
+            for ($i = $ForegroundColor.Length; $i -lt $Message.Length; $i++) { Write-Host -Object $Message[$i] -ForegroundColor $DefaultColor -NoNewLine }
+        }
+        else {
+            for ($i = 0; $i -lt $ForegroundColor.Length ; $i++) { Write-Host -Object $Message[$i] -ForegroundColor $ForegroundColor[$i] -BackgroundColor $BackgroundColor[$i] -NoNewLine }
+            for ($i = $ForegroundColor.Length; $i -lt $Message.Length; $i++) { Write-Host -Object $Message[$i] -ForegroundColor $DefaultColor -BackgroundColor $BackgroundColor[0] -NoNewLine }
         }
     }
+
     if ($NoNewLine -eq $true) { Write-Host -NoNewline } else { Write-Host } # Support for no new line
-    if ($LinesAfter -ne 0) {  for ($i = 0; $i -lt $LinesAfter; $i++) { Write-Host -Object "`n" } }  # Add empty line after
+    if ($TrailingSpace -ne 0) {  for ($i = 0; $i -lt $TrailingSpace; $i++) { Write-Host -Object "`n" } }  # Add empty line after
     if ($LogFile -ne "") {
         # Save to file
         $TextToFile = ""
-        for ($i = 0; $i -lt $Text.Length; $i++) {
-            $TextToFile += $Text[$i]
+        for ($i = 0; $i -lt $Message.Length; $i++) {
+            $TextToFile += $Message[$i]
         }
         try {
-            if ($LogTime) {
-                Write-Output -InputObject "[$([datetime]::Now.ToString($TimeFormat))]$TextToFile" | Out-File -FilePath $LogFile -Encoding $Encoding -Append
-            } else {
-                Write-Output -InputObject "$TextToFile" | Out-File -FilePath $LogFile -Encoding $Encoding -Append
+            if ($NoLogTimestamp) {
+                Write-Output -InputObject "$TextToFile" |
+                    Add-Content -Path $LogFile -Encoding $OutputEncoding
             }
-        } catch {
-            $_.Exception
+            else {
+                Write-Output -InputObject "[$([datetime]::Now.ToString($DateTimeFormat))]$TextToFile" |
+                    Add-Content -Path $LogFile -Encoding $OutputEncoding
+            }
+        }
+        catch {
+            $PSCmdlet.WriteError($_)
         }
     }
 }

--- a/Public/PSWriteColor.psm1
+++ b/Public/PSWriteColor.psm1
@@ -1,0 +1,228 @@
+function Write-Color {
+    <#
+	.SYNOPSIS
+        Write-Color is a wrapper around Write-Host.
+
+        It provides:
+        - Easy manipulation of colors,
+        - Logging output to file (log)
+        - Nice formatting options out of the box.
+
+	.DESCRIPTION
+        Author: przemyslaw.klys at evotec.pl
+        Project website: https://evotec.xyz/hub/scripts/write-color-ps1/
+        Project support: https://github.com/EvotecIT/PSWriteColor
+
+        Original idea: Josh (https://stackoverflow.com/users/81769/josh)
+
+	.EXAMPLE
+    Write-Color -Text "Red ", "Green ", "Yellow " -Color Red,Green,Yellow
+
+    .EXAMPLE
+	Write-Color -Text "This is text in Green ",
+					"followed by red ",
+					"and then we have Magenta... ",
+					"isn't it fun? ",
+					"Here goes DarkCyan" -Color Green,Red,Magenta,White,DarkCyan
+
+    .EXAMPLE
+	Write-Color -Text "This is text in Green ",
+					"followed by red ",
+					"and then we have Magenta... ",
+					"isn't it fun? ",
+                    "Here goes DarkCyan" -Color Green,Red,Magenta,White,DarkCyan -StartTab 3 -LinesBefore 1 -LinesAfter 1
+
+    .EXAMPLE
+	Write-Color "1. ", "Option 1" -Color Yellow, Green
+	Write-Color "2. ", "Option 2" -Color Yellow, Green
+	Write-Color "3. ", "Option 3" -Color Yellow, Green
+	Write-Color "4. ", "Option 4" -Color Yellow, Green
+	Write-Color "9. ", "Press 9 to exit" -Color Yellow, Gray -LinesBefore 1
+
+    .EXAMPLE
+	Write-Color -LinesBefore 2 -Text "This little ","message is ", "written to log ", "file as well." `
+				-Color Yellow, White, Green, Red, Red -LogFile "C:\testing.txt" -TimeFormat "yyyy-MM-dd HH:mm:ss"
+	Write-Color -Text "This can get ","handy if ", "want to display things, and log actions to file ", "at the same time." `
+				-Color Yellow, White, Green, Red, Red -LogFile "C:\testing.txt"
+
+    .EXAMPLE
+    # Added in 0.5
+    Write-Color -T "My text", " is ", "all colorful" -C Yellow, Red, Green -B Green, Green, Yellow
+    wc -t "my text" -c yellow -b green
+    wc -text "my text" -c red
+
+    .NOTES
+        CHANGELOG
+
+        Version 0.5 (25th April 2018)
+        -----------
+        - Added backgroundcolor
+        - Added aliases T/B/C to shorter code
+        - Added alias to function (can be used with "WC")
+        - Fixes to module publishing
+
+        Version 0.4.0-0.4.9 (25th April 2018)
+        -------------------
+        - Published as module
+        - Fixed small issues
+
+        Version 0.31 (20th April 2018)
+        ------------
+        - Added Try/Catch for Write-Output (might need some additional work)
+        - Small change to parameters
+
+        Version 0.3 (9th April 2018)
+        -----------
+        - Added -ShowTime
+        - Added -NoNewLine
+        - Added function description
+        - Changed some formatting
+
+        Version 0.2
+        -----------
+        - Added logging to file
+
+        Version 0.1
+        -----------
+        - First draft
+
+        Additional Notes:
+        - TimeFormat https://msdn.microsoft.com/en-us/library/8kb3ddd4.aspx
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0, Mandatory, ValueFromPipeline)]
+        [Alias('Text')]
+        [string[]]
+        $Message,
+
+        [Alias('Color', 'FGC')]
+        [ConsoleColor[]]
+        $ForegroundColor = 'White',
+
+        [Alias('BGC')]
+        [ConsoleColor[]]
+        $BackgroundColor,
+
+        [Alias('StartTab')]
+        [ValidateRange(0, 5)]
+        [int]
+        $Indent = 0,
+
+        [Alias('LinesBefore')]
+        [ValidateRange(0, 10)]
+        [int]
+        $LeadingSpace = 0,
+
+        [Alias('LinesAfter')]
+        [ValidateRange(0, 10)]
+        [int]
+        $TrailingSpace = 0,
+
+        [Alias('File', 'L')]
+        [ValidateScript( { Test-Path -IsValid $_ })]
+        [string]
+        $LogFile,
+
+        [Alias('DateFormat', 'TimeFormat')]
+        [string]
+        $DateTimeFormat = "yyyy-MM-dd HH:mm:ss",
+
+        [Alias('LTS')]
+        [switch]
+        $NoLogTimestamp,
+
+        [Alias('Encoding')]
+        [System.Text.Encoding]
+        $OutputEncoding = [System.Text.Encoding]::UTF8,
+
+        [switch]
+        $ShowTime,
+
+        [switch]
+        $NoNewLine
+    )
+    begin {
+        if ($PSBoundParameters.ContainsKey('LogFile')) { $StringBuilder = [System.Text.StringBuilder]::new() }
+
+        $InvalidParams = ($BackgroundColor.Count -gt 0 -and $BackgroundColor.Count -ne $ForegroundColor.Count) -or
+        $ForegroundColor.Count -gt $Message.Count -or
+        $BackgroundColor.Count -gt $Message.Count
+
+        if ($InvalidParams) {
+            $ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
+                [System.Management.Automation.ParameterBindingException]::new(
+                    'The number of provided Foreground and Background colors does not match, or more colors were provided than entered messages.'
+                ),
+                'InvalidColorMapping', # ErrorID
+                [System.Management.Automation.ErrorCategory]::InvalidArgument, # Category
+                $null # Target
+            )
+
+            $PSCmdlet.ThrowTerminatingError($ErrorRecord)
+        }
+
+        # Add leading lines
+        Write-Host ("`n" * $LeadingSpace) @BaseParams
+
+        if ($ShowTime) {
+            # Add Time before output
+            Write-Host ('[{0}]' -f [datetime]::Now.ToString($DateTimeFormat)) @BaseParams
+        }
+    }
+    process {
+        # Add TABS before text
+        Write-Host ("`t" * $Indent) @BaseParams
+
+        if ($PSBoundParameters.ContainsKey('ForegroundColor') -or $PSBoundParameters.ContainsKey('BackgroundColor')) {
+            # Fallback defaults if one of the values isn't set
+            $LastForegroundColor = [console]::ForegroundColor
+            $LastForegroundColor = [console]::BackgroundColor
+
+            # The real deal coloring
+            for ($i = 0; $i -lt $Message.Count; $i++) {
+                $CurrentFGColor = if ($ForegroundColor[$i]) { $ForegroundColor[$i] } else { $LastForegroundColor }
+                $CurrentBGColor = if ($BackgroundColor[$i]) { $BackgroundColor[$i] } else { $LastBackgroundColor }
+
+                $WriteParams = @{
+                    NoNewLine       = $true
+                    ForegroundColor = $CurrentFGColor
+                    BackgroundColor = $CurrentBGColor
+                }
+
+                Write-Host $Message[$i] @WriteParams
+                if ($PSBoundParameters.ContainsKey('LogFile')) { $StringBuilder.Append($Message[$i]) > $null }
+
+                # Store last color set, in case next iteration doesn't have a set color
+                $LastForegroundColor, $LastBackgroundColor = $CurrentFGColor, $CurrentBGColor
+            }
+        }
+        else {
+            Write-Host $Message -NoNewline
+        }
+
+        if (-not $NoNewLine) {
+            Write-Host
+        }
+
+        Write-Host ("`n" * $TrailingSpace) # Add empty line after
+    }
+    end {
+        if ($PSBoundParameters.ContainsKey('LogFile')) {
+            # Save to file
+
+            try {
+                if ($NoLogTimestamp) {
+                    $StringBuilder.ToString() | Add-Content -Path $LogFile -Encoding $OutputEncoding
+                }
+                else {
+                    "[{0}]{1}" -f [datetime]::Now.ToString($DateTimeFormat), $StringBuilder.ToString() |
+                        Add-Content -Path $LogFile -Encoding $OutputEncoding
+                }
+            }
+            catch {
+                $PSCmdlet.WriteError($_)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Attempted to cleanup code and more thoroughly define params, in keeping with established 'standard' names for common parameters.

There are a lot of changes here, please review carefully and feel free to select only what you need. I would recommend testing it in practice and ensure it functions as you expect.

There are further changes that I would make (notably the complete removal of the `wc` alias as well as the single-letter parameter aliases, but they appear to be deliberate choices, so I've let them be.

Several parameters were renamed or repurposed, with old names being retained as aliases to prevent as much breakage as possible.

Some behaviour may differ slightly, but I believe this should mimic the original functionality. 