### PR TITLE
Only center horizontally if line is shorter than window width

### DIFF
--- a/Public/Write-Color.ps1
+++ b/Public/Write-Color.ps1
@@ -136,15 +136,15 @@ function Write-Color {
             return
         }
         if ($LinesBefore -ne 0) { for ($i = 0; $i -lt $LinesBefore; $i++) { Write-Host -Object "`n" -NoNewline } } # Add empty line before
-                If ($HorizontalCenter) {
+        if ($HorizontalCenter) {
             $MessageLength = 0
-            ForEach ($Value in $Text) {
+            foreach ($Value in $Text) {
                 $MessageLength += $Value.Length
             }
-        
+
             $WindowWidth = $Host.UI.RawUI.BufferSize.Width
             $CenterPosition = [Math]::Max(0, $WindowWidth / 2 - [Math]::Floor($MessageLength / 2))
-        
+
             # Only write spaces to the console if window width is greater than the message length
             if ($WindowWidth -ge $MessageLength) {
                 Write-Host ("{0}" -f (' ' * $CenterPosition)) -NoNewline
@@ -182,7 +182,7 @@ function Write-Color {
         }
         $Saved = $false
         $Retry = 0
-        Do {
+        do {
             $Retry++
             try {
                 if ($LogTime) {
@@ -198,6 +198,6 @@ function Write-Color {
                     Write-Warning "Write-Color - Couldn't write to log file $($_.Exception.Message). Retrying... ($Retry/$LogRetry)"
                 }
             }
-        } Until ($Saved -eq $true -or $Retry -ge $LogRetry)
+        } until ($Saved -eq $true -or $Retry -ge $LogRetry)
     }
 }

--- a/Public/Write-Color.ps1
+++ b/Public/Write-Color.ps1
@@ -136,12 +136,19 @@ function Write-Color {
             return
         }
         if ($LinesBefore -ne 0) { for ($i = 0; $i -lt $LinesBefore; $i++) { Write-Host -Object "`n" -NoNewline } } # Add empty line before
-        if ($HorizontalCenter) {
+                If ($HorizontalCenter) {
             $MessageLength = 0
-            foreach ($Value in $Text) {
+            ForEach ($Value in $Text) {
                 $MessageLength += $Value.Length
             }
-            Write-Host ("{0}" -f (' ' * ([Math]::Max(0, $Host.UI.RawUI.BufferSize.Width / 2) - [Math]::Floor($MessageLength / 2)))) -NoNewline 
+        
+            $WindowWidth = $Host.UI.RawUI.BufferSize.Width
+            $CenterPosition = [Math]::Max(0, $WindowWidth / 2 - [Math]::Floor($MessageLength / 2))
+        
+            # Only write spaces to the console if window width is greater than the message length
+            if ($WindowWidth -ge $MessageLength) {
+                Write-Host ("{0}" -f (' ' * $CenterPosition)) -NoNewline
+            }
         } # Center the line horizontally according to the powershell window size
         if ($StartTab -ne 0) { for ($i = 0; $i -lt $StartTab; $i++) { Write-Host -Object "`t" -NoNewline } }  # Add TABS before text
         if ($StartSpaces -ne 0) { for ($i = 0; $i -lt $StartSpaces; $i++) { Write-Host -Object ' ' -NoNewline } }  # Add SPACES before text


### PR DESCRIPTION
Updated the HorizontalCenter to calculate the line length and console window width and compare them before applying any spaces to the console window. This stops errors when the line is longer than the console windows width.